### PR TITLE
output should adapt to actual width of the terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- [#13] Output result: output now adapts to the actual window width of the terminal, Thanks to [@boris-brtan]
+
 ### Fixed
 - [#14] Yaml indent checker: add right indents for comment line without in bottom, Thanks to [@DavidOstrozlik]
 
@@ -68,9 +71,11 @@
 - create base command to check yaml sort
 - create `--diff` mode
 
+[@boris-brtan]: https://github.com/boris-brtan
 [@DavidOstrozlik]: https://github.com/DavidOstrozlik
 
 [#14]: https://github.com/sspooky13/yaml-standards/issues/14
+[#13]: https://github.com/sspooky13/yaml-standards/pull/13
 
 [Unreleased]: https://github.com/sspooky13/yaml-standards/compare/4.0.0...HEAD
 [4.0.0]: https://github.com/sspooky13/yaml-standards/compare/3.1.1...4.0.0

--- a/src/ProcessOutput.php
+++ b/src/ProcessOutput.php
@@ -53,7 +53,7 @@ class ProcessOutput
         $this->countOfFiles = $countOfFiles;
         $this->progressLine = [];
         $this->progressLength = strlen(sprintf('%d/%1$d (%3d%%)', $this->countOfFiles, 100)) + 2;
-        $this->maxLineWidth = (new Terminal())->getWidth() - $this->progressLength;
+        $this->maxLineWidth = (new Terminal())->getWidth() - $this->progressLength - 1; // -1 because result is escaped after every file in windows
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?                      | no
| New feature?                  | no
| BC breaks?                    | no
| Standards and tests pass?     | yes
| Fixes issues                  | during the tests of implementation in our [monorepo](shopsys/shopsys/pull/539) we have 175 yaml files checked and if we do not have opened terminal window with so many columns it will wrap into almost infinity
| License                       | MIT

## Before
![image](https://user-images.githubusercontent.com/39240194/51855842-7d598f80-232e-11e9-9cab-844c2605404e.png)
![image](https://user-images.githubusercontent.com/39240194/51855875-94987d00-232e-11e9-9446-1f0da06784dd.png)


## After

![image](https://user-images.githubusercontent.com/39240194/51855685-1f2cac80-232e-11e9-92e1-ac89440fcd8f.png)
![image](https://user-images.githubusercontent.com/39240194/51855737-3f5c6b80-232e-11e9-9b8f-3fb6b95222ca.png)

