### PR TITLE
Include PHPParralelLint for installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 - [#14] Yaml indent checker: add right indents for comment line without in bottom, Thanks to [@DavidOstrozlik]
+- [#18] Add missing necessary `jakub-onderka/php-parallel-lint` to composer require, Thanks to [@ChrisDBrown]
 
 ## [4.0.0] - 2019-01-21
 ### Added
@@ -71,9 +72,11 @@
 - create base command to check yaml sort
 - create `--diff` mode
 
+[@ChrisDBrown]: https://github.com/ChrisDBrown
 [@boris-brtan]: https://github.com/boris-brtan
 [@DavidOstrozlik]: https://github.com/DavidOstrozlik
 
+[#18]: https://github.com/sspooky13/yaml-standards/pull/18
 [#14]: https://github.com/sspooky13/yaml-standards/issues/14
 [#13]: https://github.com/sspooky13/yaml-standards/pull/13
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "php": "~5.6 || ~7.0",
         "symfony/console": "~3.0 || ~4.0.10",
         "symfony/yaml": "~3.0 || ~4.0.10",
-        "sebastian/diff": "~1.4 || ~2.0 || ~3.0"
+        "sebastian/diff": "~1.4 || ~2.0 || ~3.0",
+        "jakub-onderka/php-parallel-lint": "^0.9"
     },
     "require-dev": {
         "phing/phing": "2.16.*",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?                      | yes
| New feature?                  | no
| BC breaks?                    | no
| Standards and tests pass?     | no
| Fixes issues                  | #17 
| License                       | MIT

Include PHPParralelLint for all installs to ensure it's possible to run `YamlFilesPathService::getPathToYamlFiles`