### PR TITLE
YamlFilesPathService: ignore uniterable filepaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- [#31] Yaml files path service: ignore uniterable filepaths, Thanks to [@PetrHeinz]
 
 ## [4.2.4] - 2019-07-26
 ### Fixed
@@ -129,6 +131,7 @@ patchesJson6902:
 [@DavidOstrozlik]: https://github.com/DavidOstrozlik
 [@PetrHeinz]: https://github.com/PetrHeinz
 
+[#31]: https://github.com/sspooky13/yaml-standards/pull/31
 [#27]: https://github.com/sspooky13/yaml-standards/pull/27
 [#18]: https://github.com/sspooky13/yaml-standards/pull/18
 [#14]: https://github.com/sspooky13/yaml-standards/issues/14

--- a/src/Command/Service/YamlFilesPathService.php
+++ b/src/Command/Service/YamlFilesPathService.php
@@ -7,7 +7,6 @@ use RecursiveIteratorIterator;
 use RecursiveRegexIterator;
 use RegexIterator;
 use Symfony\Component\Console\Output\OutputInterface;
-use UnexpectedValueException;
 
 class YamlFilesPathService
 {
@@ -29,16 +28,15 @@ class YamlFilesPathService
                 continue;
             }
 
-            try {
-                $recursiveDirectoryIterator = new RecursiveDirectoryIterator($pathToDirOrFile);
-                $recursiveIteratorIterator = new RecursiveIteratorIterator($recursiveDirectoryIterator);
-                $regexIterator = new RegexIterator($recursiveIteratorIterator, '/^.+\.(ya?ml(\.dist)?)$/i', RecursiveRegexIterator::GET_MATCH);
+            $recursiveIteratorIterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($pathToDirOrFile),
+                RecursiveIteratorIterator::LEAVES_ONLY,
+                RecursiveIteratorIterator::CATCH_GET_CHILD
+            );
+            $regexIterator = new RegexIterator($recursiveIteratorIterator, '/^.+\.(ya?ml(\.dist)?)$/i', RecursiveRegexIterator::GET_MATCH);
 
-                foreach ($regexIterator as $pathToFile) {
-                    $pathToFiles[] = reset($pathToFile);
-                }
-            } catch (UnexpectedValueException $exception) {
-                $output->writeln(sprintf('Error was caught: %s' . PHP_EOL, $exception->getMessage()));
+            foreach ($regexIterator as $pathToFile) {
+                $pathToFiles[] = reset($pathToFile);
             }
         }
 

--- a/src/Command/Service/YamlFilesPathService.php
+++ b/src/Command/Service/YamlFilesPathService.php
@@ -6,16 +6,14 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RecursiveRegexIterator;
 use RegexIterator;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class YamlFilesPathService
 {
     /**
      * @param string[] $pathToDirsOrFiles
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return string[]
      */
-    public static function getPathToYamlFiles(array $pathToDirsOrFiles, OutputInterface $output)
+    public static function getPathToYamlFiles(array $pathToDirsOrFiles)
     {
         $pathToFiles = [];
         foreach ($pathToDirsOrFiles as $pathToDirOrFile) {

--- a/src/Command/YamlCommand.php
+++ b/src/Command/YamlCommand.php
@@ -58,8 +58,8 @@ class YamlCommand extends Command
 
         $inputSettingData = new InputSettingData($input);
 
-        $pathToYamlFiles = YamlFilesPathService::getPathToYamlFiles($inputSettingData->getPathToDirsOrFiles(), $output);
-        $pathToSkippedYamlFiles = YamlFilesPathService::getPathToYamlFiles($inputSettingData->getExcludedPaths(), $output);
+        $pathToYamlFiles = YamlFilesPathService::getPathToYamlFiles($inputSettingData->getPathToDirsOrFiles());
+        $pathToSkippedYamlFiles = YamlFilesPathService::getPathToYamlFiles($inputSettingData->getExcludedPaths());
         $processOutput = new ProcessOutput(count($pathToYamlFiles));
 
         $fixerInterfaces = StandardClassesLoaderService::getFixerClassesByInputSettingData($inputSettingData);

--- a/tests/Command/Service/YamlFilesPathServiceTest.php
+++ b/tests/Command/Service/YamlFilesPathServiceTest.php
@@ -3,7 +3,6 @@
 namespace YamlStandards\Command\Service;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Output\NullOutput;
 
 class YamlFilesPathServiceTest extends TestCase
 {
@@ -11,7 +10,7 @@ class YamlFilesPathServiceTest extends TestCase
     {
         $pathToDir = ['./tests/yamlFiles/unSorted/'];
 
-        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToDir, new NullOutput());
+        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToDir);
 
         $this->assertCount(6, $yamlFiles);
     }
@@ -23,7 +22,7 @@ class YamlFilesPathServiceTest extends TestCase
             './tests/yamlFiles/unSorted/route',
         ];
 
-        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToDirs, new NullOutput());
+        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToDirs);
 
         $this->assertCount(3, $yamlFiles);
     }
@@ -35,7 +34,7 @@ class YamlFilesPathServiceTest extends TestCase
             './tests/yamlFiles/unSorted/route/symfony-route.yml',
         ];
 
-        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToFiles, new NullOutput());
+        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToFiles);
 
         $this->assertCount(2, $yamlFiles);
     }
@@ -49,7 +48,7 @@ class YamlFilesPathServiceTest extends TestCase
             './tests/yamlFiles/unSorted/service',
         ];
 
-        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToDirsAndFiles, new NullOutput());
+        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToDirsAndFiles);
 
         $this->assertCount(6, $yamlFiles);
     }
@@ -58,7 +57,7 @@ class YamlFilesPathServiceTest extends TestCase
     {
         $pathToFile = ['./tests/yamlFiles/unSorted/yaml-getting-started.yml'];
 
-        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToFile, new NullOutput());
+        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToFile);
 
         $this->assertEquals($pathToFile, $yamlFiles);
     }
@@ -67,7 +66,7 @@ class YamlFilesPathServiceTest extends TestCase
     {
         $pathToDirs = ['./tests/yamlFiles/unSorted/config/', './tests/yamlFiles/unSorted/route/'];
 
-        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToDirs, new NullOutput());
+        $yamlFiles = YamlFilesPathService::getPathToYamlFiles($pathToDirs);
 
         $expectedYamlFiles = [
             './tests/yamlFiles/unSorted/config/symfony-config.yml',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?                      | yes
| New feature?                  | yes (?)
| BC breaks?                    | no
| Standards and tests pass?     | yes
| Fixes issues                  | #...
| License                       | MIT

- currently (i.e. before this PR), when an exception is thrown while iterating the directories, only a part of the filenames get returned by `getPathToYamlFiles()` method
    - a warning is displayed, eg. *Error was caught: RecursiveDirectoryIterator::__construct(/var/www/html/var/postgres-data/pgdata): failed to open dir: Permission denied*
    - not sure what the intention was but seeing that an undocumented subset of filepaths is returned by the function, I see that as a bug (it might cause to not check some files that should have been checked, or quite possibly even check some files that should have been excluded)
- `RecursiveIteratorIterator::CATCH_GET_CHILD` will ignore exceptions thrown while iterating (see [php.net](https://www.php.net/manual/en/recursiveiteratoriterator.construct.php))
- this ignoring is helpful when some directories are unaccessible, eg. because of file permissions
- sadly, there is no warning displayed as it is not supported by the `RecursiveIteratorIterator` class
- try-catch block is unnecessary anymore
