### PR TITLE
YamlService::isKeyInStartOfString(): stop matching strings containing colons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - [#31] Yaml files path service: ignore uniterable filepaths, Thanks to [@PetrHeinz]
 - [#32] Yaml indent: fix situation when key is without value and is not parent, Thanks to [@PetrHeinz]
+- [#35] Yaml indent: fix right indent for arrays with unquoted colons, Thanks to [@PetrHeinz]
 
 ## [4.2.4] - 2019-07-26
 ### Fixed
@@ -132,6 +133,7 @@ patchesJson6902:
 [@DavidOstrozlik]: https://github.com/DavidOstrozlik
 [@PetrHeinz]: https://github.com/PetrHeinz
 
+[#35]: https://github.com/sspooky13/yaml-standards/pull/35
 [#32]: https://github.com/sspooky13/yaml-standards/pull/32
 [#31]: https://github.com/sspooky13/yaml-standards/pull/31
 [#27]: https://github.com/sspooky13/yaml-standards/pull/27

--- a/src/Model/Component/YamlService.php
+++ b/src/Model/Component/YamlService.php
@@ -108,7 +108,7 @@ class YamlService
      */
     public static function isKeyInStartOfString($value)
     {
-        return (bool)preg_match('~^(' . Inline::REGEX_QUOTED_STRING . '|[^ \'"{\[].*?) *:~u', $value);
+        return (bool)preg_match('~^(' . Inline::REGEX_QUOTED_STRING . '|[^ \'"{\[].*?) *:(\s|$)~u', $value);
     }
 
     /**

--- a/tests/Model/YamlIndent/resource/fixed/arraysWithUnquotedColons.yml
+++ b/tests/Model/YamlIndent/resource/fixed/arraysWithUnquotedColons.yml
@@ -1,0 +1,8 @@
+foo:
+    bar:
+        - test_url=https://www.test_url.com/
+        - test_url="https://www.test_url.com/"
+        - test_url:"https://www.test_url.com/"
+        - test_url:https://www.test_url.com/
+        - https://www.test_url.com/
+        - "https://www.test_url.com/"

--- a/tests/Model/YamlIndent/resource/unfixed/arraysWithUnquotedColons.yml
+++ b/tests/Model/YamlIndent/resource/unfixed/arraysWithUnquotedColons.yml
@@ -1,0 +1,8 @@
+foo:
+    bar:
+        -   test_url=https://www.test_url.com/
+        -   test_url="https://www.test_url.com/"
+        -   test_url:"https://www.test_url.com/"
+        -   test_url:https://www.test_url.com/
+        -   https://www.test_url.com/
+        -   "https://www.test_url.com/"


### PR DESCRIPTION
- for the line to be considered a key-value pair, there must be a whitespace after the colon or the line must end immediately after the colon
- see [Yaml\Parser implementation in Symfony v4.3.2](https://github.com/symfony/symfony/blob/v4.3.2/src/Symfony/Component/Yaml/Parser.php#L191)

| Q             | A
| ------------- | ---
| Bug fix?                      | yes
| New feature?                  | no
| BC breaks?                    | no (?)
| Fixes issues                  | fixes #34
| License                       | MIT

**I haven't actually tested the fix, it was just an idea what could be wrong in the key-value pair matching.**

Unit tests would help a lot while catching such issues as well as for writing regression tests to be sure that the issue will not return in the future. End-to-end tests are fine, but they are not particularly good at handling edge cases and pinpointing the piece of buggy code. However, I don't have the time to create a PR adding them.