### PR TITLE
simplification of build matrix in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,15 @@
 language: php
 
-matrix:
-  include:
-    - php: '5.6'
-      env: DEPENDENCIES=lowest
-    - php: '5.6'
-      env: DEPENDENCIES=highest
+php:
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - '7.2'
+  - '7.3'
 
-    - php: '7.0'
-      env: DEPENDENCIES=lowest
-    - php: '7.0'
-      env: DEPENDENCIES=highest
-
-    - php: '7.1'
-      env: DEPENDENCIES=lowest
-    - php: '7.1'
-      env: DEPENDENCIES=highest
-
-    - php: '7.2'
-      env: DEPENDENCIES=lowest
-    - php: '7.2'
-      env: DEPENDENCIES=highest
-
-    - php: '7.3'
-      env: DEPENDENCIES=lowest
-    - php: '7.3'
-      env: DEPENDENCIES=highest
+env:
+  - DEPENDENCIES=lowest
+  - DEPENDENCIES=highest
 
 before_script:
   - composer self-update


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?                      | no
| New feature?                  | no
| BC breaks?                    | no
| License                       | MIT

If you need to build every combination, you can just write down the possibilities for `php` and `env`, not all the specific combinations. See [docs on Build Matrix](https://docs.travis-ci.com/user/build-matrix/)
