### PR TITLE
Use sys_get_temp_dir() as default cache dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- [#78] Use system temp dir as default cache dir instead of root of project, Thanks to [@techi602]
 
 ## [8.0.1]
+### Fixed
 - [#76] Files path service: only use GLOB_BRACE when available
 
 ## [8.0.0] - 2023-02-26
@@ -239,11 +242,13 @@ patchesJson6902:
 - create base command to check yaml sort
 - create `--diff` mode
 
+[@techi602]: https://github.com/techi602
 [@ChrisDBrown]: https://github.com/ChrisDBrown
 [@boris-brtan]: https://github.com/boris-brtan
 [@DavidOstrozlik]: https://github.com/DavidOstrozlik
 [@PetrHeinz]: https://github.com/PetrHeinz
 
+[#78]: https://github.com/sspooky13/yaml-standards/pull/78
 [#76]: https://github.com/sspooky13/yaml-standards/issues/76
 [#72]: https://github.com/sspooky13/yaml-standards/issues/72
 [#71]: https://github.com/sspooky13/yaml-standards/issues/71

--- a/src/Command/YamlCommand.php
+++ b/src/Command/YamlCommand.php
@@ -35,7 +35,7 @@ class YamlCommand extends Command
             ->setDescription('Check yaml files respect standards')
             ->addArgument(self::ARGUMENT_PATH_TO_CONFIG_FILE, InputArgument::OPTIONAL, 'Path to configuration file. By default configuration file is looking in root directory', './yaml-standards.yaml')
             ->addOption(self::OPTION_FIX, null, InputOption::VALUE_NONE, 'Automatically fix problems')
-            ->addOption(self::OPTION_PATH_TO_CACHE_DIR, null, InputOption::VALUE_REQUIRED, 'Custom path to cache dir', '/')
+            ->addOption(self::OPTION_PATH_TO_CACHE_DIR, null, InputOption::VALUE_REQUIRED, 'Custom path to cache dir', sys_get_temp_dir() . '/')
             ->addOption(self::OPTION_DISABLE_CACHE, null, InputOption::VALUE_NONE, 'Disable cache functionality');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?                      | no
| New feature?                  | no
| BC breaks?                    | no
| Fixes issues                  | 
| License                       | MIT

Using root dir `/` as default cache dir is generally bad idea since the root dir is usually not writable.  
Therefore using `sys_get_temp_dir()` is much more convenient way to set default writable dir instead of passing optional argument
`vendor/bin/yaml-standards --path-to-cache-dir=/tmp/` 
