### PR TITLE
Add option to hide progress bar using --no-progress-bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- [#79] Added option to hide progress bar, Thanks to [@techi602]
+
 ### Changed
 - [#78] Use system temp dir as default cache dir instead of root of project, Thanks to [@techi602]
 
@@ -248,6 +251,7 @@ patchesJson6902:
 [@DavidOstrozlik]: https://github.com/DavidOstrozlik
 [@PetrHeinz]: https://github.com/PetrHeinz
 
+[#79]: https://github.com/sspooky13/yaml-standards/pull/79
 [#78]: https://github.com/sspooky13/yaml-standards/pull/78
 [#76]: https://github.com/sspooky13/yaml-standards/issues/76
 [#72]: https://github.com/sspooky13/yaml-standards/issues/72

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- [#78] Use system temp dir as default cache dir instead of root of project, Thanks to [@techi602]
 
 ## [8.0.1]
+### Fixed
 - [#76] Files path service: only use GLOB_BRACE when available
 
 ## [8.0.0] - 2023-02-26
@@ -239,11 +242,13 @@ patchesJson6902:
 - create base command to check yaml sort
 - create `--diff` mode
 
+[@techi602]: https://github.com/techi602
 [@ChrisDBrown]: https://github.com/ChrisDBrown
 [@boris-brtan]: https://github.com/boris-brtan
 [@DavidOstrozlik]: https://github.com/DavidOstrozlik
 [@PetrHeinz]: https://github.com/PetrHeinz
 
+[#78]: https://github.com/sspooky13/yaml-standards/pull/78
 [#76]: https://github.com/sspooky13/yaml-standards/issues/76
 [#72]: https://github.com/sspooky13/yaml-standards/issues/72
 [#71]: https://github.com/sspooky13/yaml-standards/issues/71

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Tips:
 - `--fix` Automatically fix allowed standards problems.
 - `--path-to-cache-dir=./path/to/cache/dir/` Custom path where should be cache file stored. Default is root directory.
 - `--no-cache` Turn off cache functionality.
+- `--no-progress-bar` Turn off progress bar. Useful e.g. for nicer CI output.
 
 ## Implemented checkers
 - **YamlAlphabeticalChecker** - Check yaml file is alphabetically sorted to selected level. **This checker has fixer**.

--- a/src/Command/InputSettingData.php
+++ b/src/Command/InputSettingData.php
@@ -29,6 +29,11 @@ class InputSettingData
     private $disableCache;
 
     /**
+     * @var bool
+     */
+    private $disableProgressBar;
+
+    /**
      * @param \Symfony\Component\Console\Input\InputInterface $input
      */
     public function __construct(InputInterface $input)
@@ -39,6 +44,7 @@ class InputSettingData
         $this->fixEnabled = $input->getOption(YamlCommand::OPTION_FIX);
         $this->pathToCacheDir = $input->getOption(YamlCommand::OPTION_PATH_TO_CACHE_DIR);
         $this->disableCache = $input->getOption(YamlCommand::OPTION_DISABLE_CACHE);
+        $this->disableProgressBar = $input->getOption(YamlCommand::OPTION_DISABLE_PROGRESS_BAR);
     }
 
     /**
@@ -71,5 +77,13 @@ class InputSettingData
     public function isCacheDisabled(): bool
     {
         return $this->disableCache;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isProgressBarDisabled(): bool
+    {
+        return $this->disableProgressBar;
     }
 }

--- a/src/Command/YamlCommand.php
+++ b/src/Command/YamlCommand.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Yaml\Exception\ParseException;
@@ -25,6 +26,7 @@ class YamlCommand extends Command
     public const OPTION_FIX = 'fix';
     public const OPTION_PATH_TO_CACHE_DIR = 'path-to-cache-dir';
     public const OPTION_DISABLE_CACHE = 'no-cache';
+    public const OPTION_DISABLE_PROGRESS_BAR = 'no-progress-bar';
 
     protected static $defaultName = self::COMMAND_NAME;
 
@@ -36,7 +38,8 @@ class YamlCommand extends Command
             ->addArgument(self::ARGUMENT_PATH_TO_CONFIG_FILE, InputArgument::OPTIONAL, 'Path to configuration file. By default configuration file is looking in root directory', './yaml-standards.yaml')
             ->addOption(self::OPTION_FIX, null, InputOption::VALUE_NONE, 'Automatically fix problems')
             ->addOption(self::OPTION_PATH_TO_CACHE_DIR, null, InputOption::VALUE_REQUIRED, 'Custom path to cache dir', sys_get_temp_dir() . '/')
-            ->addOption(self::OPTION_DISABLE_CACHE, null, InputOption::VALUE_NONE, 'Disable cache functionality');
+            ->addOption(self::OPTION_DISABLE_CACHE, null, InputOption::VALUE_NONE, 'Disable cache functionality')
+            ->addOption(self::OPTION_DISABLE_PROGRESS_BAR, null, InputOption::VALUE_NONE, 'Disable progress bar. Useful e.g. for nicer CI output.');
     }
 
     /**
@@ -52,7 +55,7 @@ class YamlCommand extends Command
         $cache = $inputSettingData->isCacheDisabled() ? new NoCache() : new NativeCache();
         $cache->deleteCacheFileIfConfigFileWasChanged($pathToConfigFile, $pathToCacheDir);
 
-        $symfonyStyle = new SymfonyStyle($input, $output);
+        $symfonyStyle = new SymfonyStyle($input, $inputSettingData->isProgressBarDisabled() ? new NullOutput() : $output);
         $progressBar = $symfonyStyle->createProgressBar($yamlStandardConfigTotalData->getTotalCountOfFiles());
         $progressBar->setFormat('debug');
         $results = [[]];

--- a/src/Command/YamlCommand.php
+++ b/src/Command/YamlCommand.php
@@ -35,7 +35,7 @@ class YamlCommand extends Command
             ->setDescription('Check yaml files respect standards')
             ->addArgument(self::ARGUMENT_PATH_TO_CONFIG_FILE, InputArgument::OPTIONAL, 'Path to configuration file. By default configuration file is looking in root directory', './yaml-standards.yaml')
             ->addOption(self::OPTION_FIX, null, InputOption::VALUE_NONE, 'Automatically fix problems')
-            ->addOption(self::OPTION_PATH_TO_CACHE_DIR, null, InputOption::VALUE_REQUIRED, 'Custom path to cache dir', '/')
+            ->addOption(self::OPTION_PATH_TO_CACHE_DIR, null, InputOption::VALUE_REQUIRED, 'Custom path to cache dir', sys_get_temp_dir() . '/')
             ->addOption(self::OPTION_DISABLE_CACHE, null, InputOption::VALUE_NONE, 'Disable cache functionality');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?                      | no
| New feature?                  | yes
| BC breaks?                    | no
| Fixes issues                  | 
| License                       | MIT

It is common practise for CLI tools to have option to disable progress bar since it makes mess in CI logs. Such as
![image](https://github.com/sspooky13/yaml-standards/assets/1529526/4e36e6ae-b28d-495c-8f62-355542c10a0c)

I have added option `--no-progress-bar` similar to https://github.com/easy-coding-standard/easy-coding-standard/
