### PR TITLE
fixed PHP Deprecated:  Use of "self" in callables is deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - fixed application when using sebastian/diff version 5 (set Builder class for Differ class)
+- [#80] fixed PHP Deprecated: Use of "self" in callables is deprecated, Thanks to [@TomasLudvik]
 
 ## [8.1.0]
 ### Added
@@ -256,12 +257,14 @@ patchesJson6902:
 - create base command to check yaml sort
 - create `--diff` mode
 
+[@TomasLudvik]: https://github.com/TomasLudvik
 [@techi602]: https://github.com/techi602
 [@ChrisDBrown]: https://github.com/ChrisDBrown
 [@boris-brtan]: https://github.com/boris-brtan
 [@DavidOstrozlik]: https://github.com/DavidOstrozlik
 [@PetrHeinz]: https://github.com/PetrHeinz
 
+[#80]: https://github.com/sspooky13/yaml-standards/pull/80
 [#79]: https://github.com/sspooky13/yaml-standards/pull/79
 [#78]: https://github.com/sspooky13/yaml-standards/pull/78
 [#77]: https://github.com/sspooky13/yaml-standards/issues/77

--- a/src/Model/YamlAlphabetical/YamlSortService.php
+++ b/src/Model/YamlAlphabetical/YamlSortService.php
@@ -67,8 +67,8 @@ class YamlSortService
         $arrayWithUnderscoreKeys = array_filter($yamlArrayData, [YamlService::class, 'hasArrayKeyUnderscoreAsFirstCharacter'], ARRAY_FILTER_USE_KEY);
         $arrayWithOtherKeys = array_filter($yamlArrayData, [YamlService::class, 'hasNotArrayKeyUnderscoreAsFirstCharacter'], ARRAY_FILTER_USE_KEY);
 
-        uksort($arrayWithUnderscoreKeys, ['self', 'sortArrayAlphabetical']);
-        uksort($arrayWithOtherKeys, ['self', 'sortArrayAlphabetical']);
+        uksort($arrayWithUnderscoreKeys, [__CLASS__, 'sortArrayAlphabetical']);
+        uksort($arrayWithOtherKeys, [__CLASS__, 'sortArrayAlphabetical']);
 
         $arrayData = array_merge($arrayWithUnderscoreKeys, $arrayWithOtherKeys);
 

--- a/src/Model/YamlInline/YamlInlineChecker.php
+++ b/src/Model/YamlInline/YamlInlineChecker.php
@@ -30,8 +30,8 @@ class YamlInlineChecker extends AbstractChecker
         $yamlLines = explode("\n", $yamlContent);
         $lastYamlElement = end($yamlLines);
         $filteredYamlLines = array_filter($yamlLines, [YamlService::class, 'isLineNotBlank']);
-        $filteredYamlLines = array_filter($filteredYamlLines, ['self', 'removeCommentLine']);
-        $filteredYamlLines = array_map(['self', 'removeComments'], $filteredYamlLines);
+        $filteredYamlLines = array_filter($filteredYamlLines, [__CLASS__, 'removeCommentLine']);
+        $filteredYamlLines = array_map([__CLASS__, 'removeComments'], $filteredYamlLines);
         if (YamlService::isLineBlank($lastYamlElement)) {
             $filteredYamlLines[] = '';
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?                      | no
| New feature?                  | no
| BC breaks?                    | no
| Fixes issues                  | no
| License                       | MIT

Fixes:
PHP Deprecated:  Use of "self" in callables is deprecated in /var/www/html/vendor/sspooky13/yaml-standards/src/Model/YamlAlphabetical/YamlSortService.php on line 70
PHP Deprecated:  Use of "self" in callables is deprecated in /var/www/html/vendor/sspooky13/yaml-standards/src/Model/YamlAlphabetical/YamlSortService.php on line 71
