### PR TITLE
added support for sebastian/diff version 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - added support for Symfony 7
 - [#77] CI: add build PHP 8.3 and Symfony 7
+- [#84] added support for sebastian/diff version 6, Thanks to [@TomasLudvik]
 
 ### Removed
 - [#69][#75] dropped support PHP 7.1 and dropped support Symfony 4.1 and lower
@@ -267,6 +268,7 @@ patchesJson6902:
 [@DavidOstrozlik]: https://github.com/DavidOstrozlik
 [@PetrHeinz]: https://github.com/PetrHeinz
 
+[#84]: https://github.com/sspooky13/yaml-standards/pull/84/files
 [#83]: https://github.com/sspooky13/yaml-standards/issues/83
 [#80]: https://github.com/sspooky13/yaml-standards/pull/80
 [#79]: https://github.com/sspooky13/yaml-standards/pull/79

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/console": "^4.2.0 || ^5.0 || ^6.0 || ^7.0",
         "symfony/config": "^4.2.0 || ^5.0 || ^6.0 || ^7.0",
         "symfony/yaml": "^4.2.0 || ^5.0 || ^6.0 || ^7.0",
-        "sebastian/diff": "^3.0 || ^4.0 || ^5.0"
+        "sebastian/diff": "^3.0 || ^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phing/phing": "^2.17.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?                      | no
| New feature?                  | no
| BC breaks?                    | no
| Fixes issues                  | #...
| License                       | MIT

<!--
We are updating our dependencies in Shopsys Platform and PHPUnit 11 now requires sebastian/diff in version 6, so this is a needed change so we can make this update, thank you.
-->
